### PR TITLE
Vagrant performance

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,14 +1,8 @@
 module.exports = function (grunt) {
     // Load the plugin that provides the tasks
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.loadNpmTasks('grunt-contrib-concat');
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-contrib-cssmin');
-    grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-contrib-sass');
-    grunt.loadNpmTasks('grunt-spritesmith');
+    require('jit-grunt')(grunt, {
+        sprite: 'grunt-spritesmith'              
+    });
 
     // Project configuration.
     grunt.initConfig({

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,13 +9,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "forwarded_port", guest:8080, host: 8080, auto_correct: true
+  config.vm.network "private_network", ip: "192.168.50.4"
   config.vm.provider "virtualbox" do |v|
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
   end
 
   # Uncomment this if you want to link to a shared folder (e.g. if you are running source control and want to link it to Vagrant)
-  config.vm.synced_folder "./", "/home/vagrant/curvation", create: true, group: "vagrant", owner: "vagrant"
-
+  if (Vagrant::Util::Platform.windows?)
+    config.vm.synced_folder "./", "/home/vagrant/curvation", create: true, type: "smb"
+  else
+    config.vm.synced_folder "./", "/home/vagrant/curvation", create: true, type: "nfs"
+  end
   config.vm.provision "shell", path: "setup.sh"
 
 end

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "grunt-contrib-uglify": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-spritesmith": "^5.0.0",
-    "nodemon": "^1.5.0"
+    "nodemon": "^1.5.0",
+    "jit-grunt": "~0.9.1"
   },
   "dependencies": {
     "express": "^4.13.3",


### PR DESCRIPTION
A few changes to improve performance when using a vagrant VM :
- use of nfs synced folders on mac and linux : grunt watch move from 40 seconds to about 15 seconds
- use of smb synced folders on windows : needs testing, i don't have a working windows machine available
- use of it-grunt for plugin loading : grunt watch change from 15 seconds to about 5 seconds

TODO : test & check improvement on windows with smb synced folders
